### PR TITLE
Add passing context to the SecretProvider

### DIFF
--- a/aes.go
+++ b/aes.go
@@ -1,6 +1,7 @@
 package pii
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -11,7 +12,7 @@ import (
 )
 
 type SecretProvider[K any] interface {
-	SecretForKey(key K) ([]byte, error)
+	SecretForKey(ctx context.Context, key K) ([]byte, error)
 }
 
 type AESAnonymizer[K any] struct {
@@ -24,8 +25,8 @@ func NewAESAnonymizer[K any](secretProvider SecretProvider[K]) AESAnonymizer[K] 
 	}
 }
 
-func (a AESAnonymizer[K]) AnonymizeString(key K, value string) (string, error) {
-	secret, err := a.secretProvider.SecretForKey(key)
+func (a AESAnonymizer[K]) AnonymizeString(ctx context.Context, key K, value string) (string, error) {
+	secret, err := a.secretProvider.SecretForKey(ctx, key)
 	if err != nil {
 		return "", err
 	}
@@ -49,8 +50,8 @@ func (a AESAnonymizer[K]) AnonymizeString(key K, value string) (string, error) {
 	return fmt.Sprintf("%x", ciphertext), nil
 }
 
-func (a AESAnonymizer[K]) DeanonymizeString(key K, value string) (string, error) {
-	secret, err := a.secretProvider.SecretForKey(key)
+func (a AESAnonymizer[K]) DeanonymizeString(ctx context.Context, key K, value string) (string, error) {
+	secret, err := a.secretProvider.SecretForKey(ctx, key)
 	if err != nil {
 		return "", err
 	}

--- a/anonymizer_test.go
+++ b/anonymizer_test.go
@@ -1,6 +1,7 @@
 package pii_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -18,6 +19,8 @@ type testStruct struct {
 }
 
 func TestStructAnonymizer(t *testing.T) {
+	ctx := context.Background()
+
 	a := pii.NewStructAnonymizer[string, testStruct](testStringAnonymizer{})
 
 	s := testStruct{
@@ -26,14 +29,14 @@ func TestStructAnonymizer(t *testing.T) {
 		Company:   "ThreeDotsLabs",
 	}
 
-	anonymized, err := a.Anonymize("id", s)
+	anonymized, err := a.Anonymize(ctx, "id", s)
 	require.NoError(t, err)
 
 	assert.Equal(t, "anonymized.id.John", anonymized.FirstName)
 	assert.Equal(t, "anonymized.id.Doe", anonymized.LastName)
 	assert.Equal(t, "ThreeDotsLabs", anonymized.Company)
 
-	deanonymized, err := a.Deanonymize("id", anonymized)
+	deanonymized, err := a.Deanonymize(ctx, "id", anonymized)
 	require.NoError(t, err)
 
 	assert.Equal(t, "John", deanonymized.FirstName)
@@ -43,11 +46,11 @@ func TestStructAnonymizer(t *testing.T) {
 
 type testStringAnonymizer struct{}
 
-func (t testStringAnonymizer) AnonymizeString(key string, value string) (string, error) {
+func (t testStringAnonymizer) AnonymizeString(_ context.Context, key string, value string) (string, error) {
 	return fmt.Sprintf("anonymized.%s.%s", key, value), nil
 }
 
-func (t testStringAnonymizer) DeanonymizeString(key string, value string) (string, error) {
+func (t testStringAnonymizer) DeanonymizeString(_ context.Context, key string, value string) (string, error) {
 	parts := strings.Split(value, ".")
 	if len(parts) != 3 {
 		return "", fmt.Errorf("invalid value")

--- a/masking.go
+++ b/masking.go
@@ -1,6 +1,9 @@
 package pii
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // MaskingAnonymizer masks struct fields, losing the original value in progress.
 // This might be useful for things like avoiding logging of sensitive information.
@@ -10,10 +13,10 @@ func NewMaskingAnonymizer[T any](mask T) MaskingAnonymizer[T] {
 	return MaskingAnonymizer[T]{}
 }
 
-func (m MaskingAnonymizer[T]) AnonymizeString(key T, value string) (string, error) {
+func (m MaskingAnonymizer[T]) AnonymizeString(_ context.Context, key T, value string) (string, error) {
 	return fmt.Sprintf("%v", key), nil
 }
 
-func (m MaskingAnonymizer[T]) DeanonymizeString(_ T, value string) (string, error) {
+func (m MaskingAnonymizer[T]) DeanonymizeString(_ context.Context, _ T, value string) (string, error) {
 	return value, nil
 }

--- a/masking_test.go
+++ b/masking_test.go
@@ -1,6 +1,7 @@
 package pii_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,8 @@ import (
 )
 
 func TestMaskingAnonymizer(t *testing.T) {
+	ctx := context.Background()
+
 	a := pii.NewStructAnonymizer[string, testStruct](pii.MaskingAnonymizer[string]{})
 
 	s := testStruct{
@@ -18,14 +21,14 @@ func TestMaskingAnonymizer(t *testing.T) {
 		Company:   "ThreeDotsLabs",
 	}
 
-	anonymized, err := a.Anonymize("***", s)
+	anonymized, err := a.Anonymize(ctx, "***", s)
 	require.NoError(t, err)
 
 	assert.Equal(t, "***", anonymized.FirstName)
 	assert.Equal(t, "***", anonymized.LastName)
 	assert.Equal(t, "ThreeDotsLabs", anonymized.Company)
 
-	deanonymized, err := a.Deanonymize("", anonymized)
+	deanonymized, err := a.Deanonymize(ctx, "", anonymized)
 	require.NoError(t, err)
 
 	assert.Equal(t, "***", deanonymized.FirstName)


### PR DESCRIPTION
__Why?__

Sometimes implementation of a `SecretProvider` may perform additional external calls. Therefore it makes sense to pass a `context` into it.

__Tests__
The existing unit tests were adjusted.